### PR TITLE
fix: graphQL query deleted extra property

### DIFF
--- a/client/src/queries/index.ts
+++ b/client/src/queries/index.ts
@@ -11,7 +11,6 @@ export const GetAllTransactions = gql`
       data
       chainId
       hash
-      receipt
     }
   }
 `;


### PR DESCRIPTION
The property receipt doesn't exist on the model for the database, therefore needs to be deleted.